### PR TITLE
Clean up servers after 10 seconds of placeholder request inactivity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.helpchat</groupId>
     <artifactId>RedisBungeeExpansion</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <packaging>jar</packaging>
 
     <name>RedisBungeeExpansion</name>

--- a/src/main/java/com/helpchat/redisbungeeexpansion/RedisBungeeExpansion.java
+++ b/src/main/java/com/helpchat/redisbungeeexpansion/RedisBungeeExpansion.java
@@ -59,7 +59,7 @@ public final class RedisBungeeExpansion extends PlaceholderExpansion implements 
 
     @Override
     public String getVersion() {
-        return "2.0.2";
+        return "2.0.3";
     }
 
     @Override


### PR DESCRIPTION
This PR adds a cleanup mechanism, making sure the expansion doesn't send plugin messages for servers forever. Not having a cleanup mechanism can cause severe resource leaks when a lot of unique servers identifiers are requested.